### PR TITLE
Fix documentation typo.

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@ Add the before-save-hook to your ~/.emacs
 #+BEGIN_SRC lisp
 (add-to-list 'load-path "/your/path/")
 (require 'py-isort)
-(add-hook 'before-save-hook 'python-isort-before-save)
+(add-hook 'before-save-hook 'py-isort-before-save)
 #+END_SRC
 
 You can also install py-isort with MELPA:


### PR DESCRIPTION
The function `python-isort-before-save` does not exist. It should be `py-isort-before-save` in the README.

I ran into this issue as I copy-pasted the `before-save-hook` from the README.  The documentation within `py-isort.el` is correct though, so it was only this one instance where this typo occurred.
