### PR TITLE
Use locate-dominating-file to find .isort.cfg

### DIFF
--- a/py-isort.el
+++ b/py-isort.el
@@ -36,8 +36,14 @@
   :type '(repeat (string :tag "option")))
 
 
+(defun py-isort--find-settings-path ()
+  (expand-file-name
+   (or (locate-dominating-file buffer-file-name ".isort.cfg")
+       (file-name-directory buffer-file-name))))
+
+
 (defun py-isort--call-executable (errbuf file)
-  (let ((default-directory (file-name-directory buffer-file-name)))
+  (let ((default-directory (py-isort--find-settings-path)))
     (zerop (apply 'call-process "isort" nil errbuf nil
                   (append `(" " , file, " ",
                             (concat "--settings-path=" default-directory))

--- a/tests.sh
+++ b/tests.sh
@@ -67,6 +67,20 @@ test_04() {
 }
 
 
+test_05() {
+    echo $FUNCNAME
+    rm $TEST_FILE || true
+    emacs --no-init-file -nw \
+          --load ./tests/tests.el \
+          --load py-isort.el \
+          ./tests/05/files/before.py \
+          -f py-isort-buffer \
+          -f write-test-file \
+          -f kill-emacs
+    diff $TEST_FILE ./tests/05/files/after.py
+}
+
+
 test_install_package() {
     echo $FUNCNAME
     emacs --no-init-file -nw \
@@ -86,6 +100,7 @@ main() {
     test_02
     test_03
     test_04
+    test_05
 }
 
 

--- a/tests/05/.isort.cfg
+++ b/tests/05/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+import_heading_stdlib=STDLIB

--- a/tests/05/files/after.py
+++ b/tests/05/files/after.py
@@ -1,0 +1,2 @@
+# STDLIB
+import re

--- a/tests/05/files/before.py
+++ b/tests/05/files/before.py
@@ -1,0 +1,1 @@
+import re


### PR DESCRIPTION
py-isort.el was passing the current files directory into isort as the
settings path, but in most large projects .isort.cfg is more likely to
be found in a parent directory.

This commit uses locate-dominating-file to look for .isort.cfg in parent
directories, and uses that path instead if it finds anything.  Otherwise
it defaults to the current directory as before.