### PR TITLE
Add isort add and remove import feature

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,6 +41,28 @@ To customize the behaviour of =isort= you can set the =py-isort-options= e.g.
 
 - =M-x py-isort-buffer RET=: Uses the =isort= tool to reformat the current buffer.
 - =M-x py-isort-region RET=: Uses the =isort= tool to reformat the current region.
+- =M-x py-isort-add-import RET=: Asks for a module that should be added to the
+  current buffer. (With =import module.name=)
+- =M-x py-isort-add-from-import RET=: Asks for a module and module item that
+  should be added to the current buffer. (With =from module import item=)
+- =M-x py-isort-remove-import RET=: Asks for a module that should be removed from
+  the current buffer, without having to be concerned with how it was originally
+  formatted.
+- =M-x py-isort-add-import-region=: Import a module from region.
+
+  Import modules from region and then delete the region. If you have
+  `whole-line-or-region' installed it may be useful to define a function like:
+
+  #+BEGIN_SRC elisp
+  (defun py-isort-add-import-whole-line-or-region ()
+    "Import module(s) from region or whole line."
+    (interactive)
+    (whole-line-or-region-call-with-region 'py-isort-add-import-region))
+  #+END_SRC
+
+  Then you can just type your import (with working autocomplete) wherever you
+  are in your code, call this function and the import will be properly sorted to
+  your normal python imports.
 
 
 ** Bugs and improvements

--- a/py-isort.el
+++ b/py-isort.el
@@ -30,10 +30,13 @@
   :prefix "py-isort-")
 
 
+;;;###autoload
 (defcustom py-isort-options nil
   "Options used for isort."
   :group 'py-isort
+  :safe 'listp
   :type '(repeat (string :tag "option")))
+;;;###autoload(put 'py-isort-options 'safe-local-variable #'listp)
 
 
 (defun py-isort--find-settings-path ()
@@ -55,6 +58,57 @@
                                            'py-isort--call-executable
                                            only-on-region
                                            "py"))
+
+
+;;;###autoload
+(defun py-isort-remove-import (import-string)
+  "Use the \"isort\" tool to remove module IMPORT-STRING from buffer."
+  (interactive "*sImport: ")
+  (let ((py-isort-options
+         (cons (format "-r %s" import-string) py-isort-options)))
+    (py-isort--call nil)))
+
+
+;;;###autoload
+(defun py-isort-add-import (import-string)
+  "Use the \"isort\" tool to import module IMPORT-STRING."
+  (interactive "*sImport: ")
+  (let ((py-isort-options
+         (cons (format "-a import %s" import-string) py-isort-options)))
+    (py-isort--call nil)))
+
+
+;;;###autoload
+(defun py-isort-add-from-import (from-string import-string)
+  "Use the \"isort\" tool to add \"from FROM-STRING import IMPORT-STRING\"."
+  (interactive "*sFrom:\nsImport: ")
+  (let ((py-isort-options
+         (cons (format "-a from %s import %s" from-string import-string)
+               py-isort-options)))
+    (py-isort--call nil)))
+
+
+;;;###autoload
+(defun py-isort-add-import-region (start end)
+  "Use the \"isort\" tool to import the module(s) from region.
+
+Import modules from point START to END and then delete the
+region.  If you have `whole-line-or-region' installed it may be
+useful to define a function like:
+
+  (defun py-isort-add-import-whole-line-or-region ()
+    \"Import module(s) from region or whole line.\"
+    (interactive)
+    (whole-line-or-region-call-with-region 'py-isort-add-import-region))
+
+Then you can just type your import (with working autocomplete)
+wherever you are in your code, call this function and the import
+will be properly sorted to your normal python imports."
+  (interactive "*r")
+  (let ((py-isort-options
+         (cons (format "-a %s" (delete-and-extract-region start end) ) py-isort-options)))
+    (py-isort--call nil)))
+
 
 
 ;;;###autoload


### PR DESCRIPTION
See https://github.com/timothycrosley/isort#adding-an-import-to-multiple-files

Quite often I'm somewhere scrolled down in the code and I need
to import something. With those functions you can stay in your current position
and easily add and remove the imports.