### PR TITLE
Add an option to set path to custom isort executable

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,6 +34,7 @@ To customize the behaviour of =isort= you can set the =py-isort-options= e.g.
 
 #+BEGIN_SRC lisp
 (setq py-isort-options '("--lines=100"))
+(setq py-isort-executable "/path/to/custom/isort")
 #+END_SRC
 
 

--- a/py-isort.el
+++ b/py-isort.el
@@ -20,6 +20,7 @@
 ;; py-isort-options e.g.
 
 ;;   (setq py-isort-options '("--lines=100"))
+;;   (setq py-isort-executable '("isort"))
 
 ;;; Code:
 
@@ -36,6 +37,12 @@
   :type '(repeat (string :tag "option")))
 
 
+(defcustom py-isort-executable "isort"
+  "Name or path to the isory executable"
+  :group 'py-isort
+  :type '(repeat (string :tag "option")))
+
+
 (defun py-isort--find-settings-path ()
   (expand-file-name
    (or (locate-dominating-file buffer-file-name ".isort.cfg")
@@ -44,14 +51,14 @@
 
 (defun py-isort--call-executable (errbuf file)
   (let ((default-directory (py-isort--find-settings-path)))
-    (zerop (apply 'call-process "isort" nil errbuf nil
+    (zerop (apply 'call-process py-isort-executable nil errbuf nil
                   (append `(" " , file, " ",
                             (concat "--settings-path=" default-directory))
                           py-isort-options)))))
 
 
 (defun py-isort--call (only-on-region)
-  (py-isort-bf--apply-executable-to-buffer "isort"
+  (py-isort-bf--apply-executable-to-buffer py-isort-executable
                                            'py-isort--call-executable
                                            only-on-region
                                            "py"))


### PR DESCRIPTION
It would be really great if it was possible to set path to a custom `isort` binary for environments where it is not always viable to run Emacs with updated `PATH` env var. I found myself in such situation in the Linux mode on a Chromebook.

This change adds `py-isort-executable` variable that is backwards compatible, which defaults to the current value of `"isort"` so should not break existing installs, but at the same time allows setting direct path to the executable.