### PR TITLE
add support for Org mode source block edit buffers

### DIFF
--- a/py-isort.el
+++ b/py-isort.el
@@ -37,9 +37,11 @@
 
 
 (defun py-isort--find-settings-path ()
-  (expand-file-name
-   (or (locate-dominating-file buffer-file-name ".isort.cfg")
-       (file-name-directory buffer-file-name))))
+  (if (string-match-p "\\*Org Src .*\\[ python \\]\\*" (buffer-name))
+      default-directory
+    (expand-file-name
+     (or (locate-dominating-file buffer-file-name ".isort.cfg")
+        (file-name-directory buffer-file-name)))))
 
 
 (defun py-isort--call-executable (errbuf file)


### PR DESCRIPTION
Prevents `py-isort--find-settings-path` to crash with `locate-dominating-file: Wrong type argument: stringp, nil` error while trying to execute interactive `py-isort-` functions inside Org mode source block edit buffer.
