### PR TITLE
adds pyproject.toml as the dominant file to look for for isort settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 buftra.el
+*.elc

--- a/py-isort.el
+++ b/py-isort.el
@@ -38,7 +38,8 @@
 
 (defun py-isort--find-settings-path ()
   (expand-file-name
-   (or (locate-dominating-file buffer-file-name ".isort.cfg")
+   (or (locate-dominating-file buffer-file-name "pyproject.toml")
+       (locate-dominating-file buffer-file-name ".isort.cfg")
        (file-name-directory buffer-file-name))))
 
 


### PR DESCRIPTION
After it's original inception as a standalone tool, isort has moved to [PyCQA](https://github.com/PyCQA/isort)
and has undergone more integration and standardization in the Python community.

Part of this gradual transition includes using `pyproject.toml` to provide settings configurations multiple Python code quality tools, including Black, flake8, etc, instead of having the settings spread out across multiple files.

Though the ideal and correct configuration should actually parse the `pyproject.toml` file to look for valid isort settings, thiscommit is a quick fix at attempting to codify this new emerging trend and standard.

It's reasonable to assume that if a project is using `pyproject.toml`, that it would soon migrate settings away from `.isort.cfg`
