### PR TITLE
Make default-directory the default search path for settings

### DIFF
--- a/py-isort.el
+++ b/py-isort.el
@@ -38,8 +38,10 @@
 
 (defun py-isort--find-settings-path ()
   (expand-file-name
-   (or (locate-dominating-file buffer-file-name ".isort.cfg")
-       (file-name-directory buffer-file-name))))
+   (if (buffer-file-name)
+       (or (locate-dominating-file buffer-file-name ".isort.cfg")
+           (file-name-directory buffer-file-name))
+     default-directory)))
 
 
 (defun py-isort--call-executable (errbuf file)

--- a/py-isort.el
+++ b/py-isort.el
@@ -39,7 +39,11 @@
 (defun py-isort--find-settings-path ()
   (expand-file-name
    (if (buffer-file-name)
-       (or (locate-dominating-file buffer-file-name ".isort.cfg")
+       (or (locate-dominating-file (file-name-directory buffer-file-name)
+                                   (lambda (p)
+                                     (directory-files (file-name-directory p)
+                                                      nil
+                                                      "^\\(.isort.cfg\\|pyproject.toml\\|setup.cfg\\|.editorconfig\\)$")))
            (file-name-directory buffer-file-name))
      default-directory)))
 


### PR DESCRIPTION
This PR provides the fallback path for searching for the isort settings file. Without this, the function `py-isort--find-settings-path` fails when `buffer-file-name` is `nil`, as in the case #19 solves for Org mode. This fix provides a more generic solution, working for non-Org mode as well.