### PR TITLE
Add a minor-mode to add/remove the save hook more easily

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,12 +20,12 @@ M-x package-install RET
 py-isort RET
 #+END_SRC
 
-Add the =before-save-hook= to your =~/.emacs=
+Add this code to your =~/.emacs=
 
 #+BEGIN_SRC lisp
 (add-to-list 'load-path "/your/path/")
 (require 'py-isort)
-(add-hook 'before-save-hook 'py-isort-before-save)
+(add-hook 'python-mode-hook #'isort-mode)
 #+END_SRC
 
 Now every time you save your Python file =isort= will be executed on the current buffer.

--- a/py-isort.el
+++ b/py-isort.el
@@ -14,7 +14,7 @@
 ;; To automatically sort imports when saving a python file, use the
 ;; following code:
 
-;;   (add-hook 'before-save-hook 'py-isort-before-save)
+;;   (add-hook 'python-mode-hook #'isort-mode)
 
 ;; To customize the behaviour of "isort" you can set the
 ;; py-isort-options e.g.
@@ -170,6 +170,14 @@
 
 ;; py-isort-bf.el ends here
 ;; END GENERATED -------------------
+
+
+(define-minor-mode py-isort-mode
+  "Automatically run isort before saving."
+  :lighter " isort"
+  (if isort-mode
+      (add-hook 'before-save-hook 'py-isort-before-save nil t)
+    (remove-hook 'before-save-hook 'py-isort-before-save t)))
 
 
 (provide 'py-isort)


### PR DESCRIPTION
I wrote this little minor mode for my own use and figured you might want to merge it here.

I changed the docs because I think using a minor mode is a simpler and more idiomatic way to enable something like this, but happy to not have those changes.

The additional `t` on the end of the add/remove hook commands make the hook local to the buffer, so that enabling the mode in one buffer doesn't enable isort everywhere.